### PR TITLE
[BUGFIX] Fix undefined method [] for NilClass

### DIFF
--- a/libraries/chef_vault_password.rb
+++ b/libraries/chef_vault_password.rb
@@ -54,7 +54,11 @@ class Chef
       Chef::Log.debug("Got answer from chef-vault")
 
       password = vault_answer[type]
-      Chef::Log.debug("Returning entry '#{type}': '#{password[0..2]}...'")
+      if password.nil?
+        Chef::Log.warn("No entry '#{type}' found in #{bag}/#{item}'")
+      else
+        Chef::Log.debug("Returning entry '#{type}': '#{password[0..2]}...'")
+      end
 
       password
     end


### PR DESCRIPTION
When a type (e.g. token instead of password) is requested but not found
in the data bag, then we can't write a log message containing the beginning
of this NilClass.